### PR TITLE
Tomotaco unitywebrequest for 2017 2

### DIFF
--- a/Assets/NCMBLeaderboardWebGL/Scripts/NCMBRestController.cs
+++ b/Assets/NCMBLeaderboardWebGL/Scripts/NCMBRestController.cs
@@ -92,7 +92,11 @@ namespace NCMBRest
 
             request.downloadHandler = new DownloadHandlerBuffer();
 
+#if UNITY_2017_2_OR_NEWER
+            yield return request.SendWebRequest();
+#else
             yield return request.Send();
+#endif
 
 #if UNITY_2017_1_OR_NEWER
             if (request.isNetworkError)


### PR DESCRIPTION
2017.2のプロジェクトで利用させて頂いたところ、
UnityWebRequest.Send() の代わりに SendWebRequest() を使う、という旨の
警告が表示されましたので修正版を pull request させて頂きます。
ご検討のほどよろしくお願い申し上げます。